### PR TITLE
Readme updates to include board and port selection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,9 +44,12 @@ We recommend Arduino IDE version 1.6.x or newer to compile and deploy Arduino sk
 2. Copy folders `eez_psu_sketch` and `libraries` from the zip archive into Arduino folder on your computer. Arduino folder is e.g. `My Documents\Arduino` on Windows or `Documents/Arduino` on Linux and Mac.
 3. Download Ethernet2 library from [here](https://github.com/eez-open/Ethernet2) and copy it to the `libraries` folder.
 4. Download SdFat library from [here](https://github.com/eez-open/SdFat) and copy it to the `libraries` folder.
-5. Open `eez_psu_sketch.ino` in Arduino IDE, check if everything is correct with Verify button
-6. Make sure that *Verify after code upload* option is not set (more details [here](https://github.com/arduino/Arduino/issues/5672)) in File... Preferences and upload the sketch using Upload button.
-7. Remote control can be accessed via Telnet client such as [putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/) (connection type: raw, port: 5025) or serial client that comes with Arduino IDE or any other you like.
+5. Open `eez_psu_sketch.ino` in Arduino IDE.
+6. Go to `Tools->Board` and select `Arduino Due (Native USB Port)`. If `Arduino Due (Native USB Port)` is not present in the list of boards then go to `Tools->Board->Boards Manager` and click on `Arduino SAM Boards` then click on the Install button. When install is done close the Board Manager then go to `Tools->Board` and select `Arduino Due (Native USB Port)`.
+7. Plug a USB cable between the PSU and your PC then go to `Tools->Port` and select the COM port for your PSU.
+8. Check if everything is correct with Verify button.
+9. Make sure that *Verify after code upload* option is not set (more details [here](https://github.com/arduino/Arduino/issues/5672)) in File... Preferences and upload the sketch using Upload button.
+10. Remote control can be accessed via Telnet client such as [putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/) (connection type: raw, port: 5025) or serial client that comes with Arduino IDE or any other you like.
 
 ### Simulator
 


### PR DESCRIPTION
I added some missing steps to the readme including how to select the right board and port. New users are probably not going to be aware that this needs to be done, or how to do it. If it isn't done then you end up with strange missing header file error messages when verifying.