### PR TITLE
SCPI limit fix for for voltage/current/power

### DIFF
--- a/eez_psu_sketch/scpi_params.cpp
+++ b/eez_psu_sketch/scpi_params.cpp
@@ -427,22 +427,21 @@ bool get_power_limit_param(scpi_t *context, float &value, const Channel *channel
 }
 
 bool get_voltage_limit_from_param(scpi_t *context, const scpi_number_t &param, float &value, const Channel *channel, const Channel::Value *cv) {
+	if (context==NULL || channel==NULL) {
+		SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+		return false;
+	}
     if (param.special) {
-		if (channel) {
-			if (param.tag == SCPI_NUM_MAX) {
-				value = channel_dispatcher::getUMaxLimit(*channel);
-			}
-			else if (param.tag == SCPI_NUM_MIN) {
-				value = channel_dispatcher::getUMin(*channel);
-			}
-			else if (param.tag == SCPI_NUM_DEF) {
-				value = channel_dispatcher::getUMaxLimit(*channel);
-			}
-			else {
-				SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
-				return false;
-			}
-		} else {
+		if (param.tag == SCPI_NUM_MAX) {
+			value = channel_dispatcher::getUMaxLimit(*channel);
+		}
+		else if (param.tag == SCPI_NUM_MIN) {
+			value = channel_dispatcher::getUMin(*channel);
+		}
+		else if (param.tag == SCPI_NUM_DEF) {
+			value = channel_dispatcher::getUMaxLimit(*channel);
+		}
+		else {
 			SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
 			return false;
 		}
@@ -455,11 +454,9 @@ bool get_voltage_limit_from_param(scpi_t *context, const scpi_number_t &param, f
 
         value = (float)param.value;
 		
-		if (channel) {
-			if (value < channel_dispatcher::getUMin(*channel) || channel_dispatcher::getUMaxLimit(*channel)) {
-				SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
-				return false;
-			}
+		if (value < channel_dispatcher::getUMin(*channel) || value > channel_dispatcher::getUMaxLimit(*channel)) {
+			SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+			return false;
 		}
     }
 
@@ -467,16 +464,23 @@ bool get_voltage_limit_from_param(scpi_t *context, const scpi_number_t &param, f
 }
 
 bool get_current_limit_from_param(scpi_t *context, const scpi_number_t &param, float &value, const Channel *channel, const Channel::Value *cv) {
+	if (context==NULL || channel==NULL) {
+		SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+		return false;
+	}
     if (param.special) {
         if (param.tag == SCPI_NUM_MAX) {
             value = channel_dispatcher::getIMaxLimit(*channel);
         }
         else if (param.tag == SCPI_NUM_MIN) {
-            value = channel_dispatcher::getIMax(*channel);
+            value = channel_dispatcher::getIMin(*channel);
         }
         else if (param.tag == SCPI_NUM_DEF) {
             value = channel_dispatcher::getIMaxLimit(*channel);
-        }
+		} else {
+			SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+			return false;
+		}
     }
     else {
         if (param.unit != SCPI_UNIT_NONE && param.unit != SCPI_UNIT_AMPER) {
@@ -485,6 +489,7 @@ bool get_current_limit_from_param(scpi_t *context, const scpi_number_t &param, f
         }
 
         value = (float)param.value;
+        
         if (value < channel_dispatcher::getIMin(*channel) || value > channel_dispatcher::getIMaxLimit(*channel)) {
             SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
             return false;
@@ -495,6 +500,10 @@ bool get_current_limit_from_param(scpi_t *context, const scpi_number_t &param, f
 }
 
 bool get_power_limit_from_param(scpi_t *context, const scpi_number_t &param, float &value, const Channel *channel, const Channel::Value *cv) {
+	if (context==NULL || channel==NULL) {
+		SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+		return false;
+	}
     if (param.special) {
         if (param.tag == SCPI_NUM_MAX) {
             value = channel_dispatcher::getPowerMaxLimit(*channel);
@@ -507,12 +516,13 @@ bool get_power_limit_from_param(scpi_t *context, const scpi_number_t &param, flo
         }
     }
     else {
-        if (param.unit != SCPI_UNIT_NONE) {
+        if (param.unit != SCPI_UNIT_NONE && param.unit != SCPI_UNIT_WATT) {
             SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
             return false;
         }
 
         value = (float)param.value;
+        
         if (value < channel_dispatcher::getPowerMinLimit(*channel) || value > channel_dispatcher::getPowerMaxLimit(*channel)) {
             SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
             return false;


### PR DESCRIPTION
This makes the SCPI handlers for setting the limit for voltage/current/power fixed and the same.

This fixes an issue where setting voltage limit failed due to:
```if (value < channel_dispatcher::getUMin(*channel) || channel_dispatcher::getUMaxLimit(*channel))```
vs
```if (value < channel_dispatcher::getUMin(*channel) || value > channel_dispatcher::getUMaxLimit(*channel))```

It also fixes an issue where setting min current limit is handled incorrectly due to:
```value = channel_dispatcher::getIMax(*channel);```
vs
```value = channel_dispatcher::getIMin(*channel);```

It also fixes an issue where setting power limit with unit suffix fails due to:
```if (param.unit != SCPI_UNIT_NONE)```
vs
```if (param.unit != SCPI_UNIT_NONE && param.unit != SCPI_UNIT_WATT)```